### PR TITLE
 fixed moviecard component querie on devices with less than 375px wide

### DIFF
--- a/src/components/Moviecard/index.scss
+++ b/src/components/Moviecard/index.scss
@@ -139,13 +139,13 @@ $lighter-blue2: rgba(86, 86, 101, 1);
   color: $lighter-blue2;
 }
 
-@media (min-width: 340px) and (max-width: 375px) {
+@media (min-width: 340px) and (max-width: 374px) {
   .cardContainer {
-    width: 40%;
-    height: 220px;
+    width: 45%;
+    height: 236px;
   }
 
   .upperPart__imagecontainer {
-    height: 173px;
+    height: 190px;
   }
 }


### PR DESCRIPTION
the size of the cards was too small, so it was fixed in order to be more alike to the original design for bigger displays.